### PR TITLE
feat: add minimal orchestrator module and tests

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1,0 +1,107 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yates-Labs/thunk/internal/cluster"
+	"github.com/Yates-Labs/thunk/internal/ingest/git"
+)
+
+// AnalyzeRepository analyzes a Git repository and returns grouped episodes
+// The repo parameter can be either a local path or a remote URL
+// Uses default grouping configuration
+func AnalyzeRepository(ctx context.Context, repo string) ([]cluster.Episode, error) {
+	config := cluster.DefaultGroupingConfig()
+	return AnalyzeRepositoryWithConfig(ctx, repo, config)
+}
+
+// AnalyzeRepositoryWithConfig analyzes a repository with custom grouping configuration
+func AnalyzeRepositoryWithConfig(ctx context.Context, repo string, config cluster.GroupingConfig) ([]cluster.Episode, error) {
+	// Check for context cancellation
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("context cancelled before analysis: %w", err)
+	}
+
+	// Step 1: Ingest repository data
+	activity, err := ingestRepository(ctx, repo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ingest repository: %w", err)
+	}
+
+	// Check for context cancellation after ingestion
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("context cancelled after ingestion: %w", err)
+	}
+
+	// Step 2: Group commits into episodes
+	episodes := activity.GroupIntoEpisodes(config)
+
+	return episodes, nil
+}
+
+// ingestRepository handles the ingestion of repository data
+// Supports both local paths and remote URLs
+func ingestRepository(ctx context.Context, repo string) (*cluster.RepositoryActivity, error) {
+	// Try to open as local repository first
+	gitRepo, err := git.OpenRepository(repo)
+	if err != nil {
+		// If local open fails, try cloning from remote URL
+		gitRepo, err = git.CloneRepository(repo)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open or clone repository '%s': %w", repo, err)
+		}
+	}
+
+	// Parse repository with reasonable defaults
+	// maxCommits: 0 = unlimited, includePatch: false for performance
+	repoData, err := git.ParseRepository(gitRepo, repo, 0, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse repository: %w", err)
+	}
+
+	// Convert to RepositoryActivity
+	activity := &cluster.RepositoryActivity{
+		Platform:       cluster.PlatformGit,
+		RepositoryURL:  repo,
+		RepositoryName: extractRepoName(repo),
+		Owner:          "", // Git doesn't have owner concept
+		DefaultBranch:  repoData.HeadBranch,
+		Commits:        repoData.Commits,
+		Artifacts:      []cluster.Artifact{}, // Git doesn't have artifacts
+		FetchedAt:      time.Now(),
+	}
+
+	return activity, nil
+}
+
+// extractRepoName extracts the repository name from a path or URL
+func extractRepoName(repo string) string {
+	// Remove trailing slash if present
+	if len(repo) > 0 && repo[len(repo)-1] == '/' {
+		repo = repo[:len(repo)-1]
+	}
+
+	// Find the last slash
+	lastSlash := -1
+	for i := len(repo) - 1; i >= 0; i-- {
+		if repo[i] == '/' {
+			lastSlash = i
+			break
+		}
+	}
+
+	// Extract name after last slash
+	name := repo
+	if lastSlash >= 0 && lastSlash < len(repo)-1 {
+		name = repo[lastSlash+1:]
+	}
+
+	// Remove .git suffix if present
+	if len(name) > 4 && name[len(name)-4:] == ".git" {
+		name = name[:len(name)-4]
+	}
+
+	return name
+}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,0 +1,184 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Yates-Labs/thunk/internal/cluster"
+)
+
+func TestAnalyzeRepository_RealRepo(t *testing.T) {
+	ctx := context.Background()
+
+	// Test with this repository (should work if we're in the repo)
+	episodes, err := AnalyzeRepository(ctx, "https://github.com/Yates-Labs/thunk")
+	if err != nil {
+		t.Fatalf("Failed to analyze repository: %v", err)
+	}
+
+	if len(episodes) == 0 {
+		t.Error("Expected at least one episode from repository")
+	}
+
+	// Verify episode structure
+	for i, episode := range episodes {
+		if episode.ID == "" {
+			t.Errorf("Episode %d has empty ID", i)
+		}
+
+		if len(episode.Commits) == 0 {
+			t.Errorf("Episode %d has no commits", i)
+		}
+
+		// Verify commits have proper structure
+		for j, commit := range episode.Commits {
+			if commit.Hash == "" {
+				t.Errorf("Episode %d, Commit %d has empty hash", i, j)
+			}
+			if commit.Author.Email == "" {
+				t.Errorf("Episode %d, Commit %d has empty author email", i, j)
+			}
+		}
+	}
+}
+
+func TestAnalyzeRepository_ContextCancellation(t *testing.T) {
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := AnalyzeRepository(ctx, "https://github.com/Yates-Labs/thunk")
+	if err == nil {
+		t.Error("Expected error when context is cancelled")
+	}
+}
+
+func TestAnalyzeRepository_InvalidRepo(t *testing.T) {
+	ctx := context.Background()
+
+	// Test with non-existent local path
+	_, err := AnalyzeRepository(ctx, "/path/that/does/not/exist")
+	if err == nil {
+		t.Error("Expected error for non-existent repository")
+	}
+
+	// Test with invalid URL
+	_, err = AnalyzeRepository(ctx, "https://github.com/invalid/repo/that/does/not/exist/123456789")
+	if err == nil {
+		t.Error("Expected error for invalid repository URL")
+	}
+}
+
+func TestAnalyzeRepositoryWithConfig(t *testing.T) {
+	// Create custom config with tighter time window
+	config := cluster.GroupingConfig{
+		MaxTimeGap:         6 * time.Hour, // Tighter time window
+		MinCommits:         2,
+		TimeWeight:         0.5,
+		AuthorWeight:       0.3,
+		FileWeight:         0.1,
+		MessageWeight:      0.05,
+		ArtifactWeight:     0.05,
+		MinSimilarityScore: 0.3,
+	}
+
+	ctx := context.Background()
+
+	episodes, err := AnalyzeRepositoryWithConfig(ctx, "https://github.com/Yates-Labs/thunk", config)
+	if err != nil {
+		t.Fatalf("Failed to analyze repository: %v", err)
+	}
+
+	// With stricter config, we might get different number of episodes
+	// Just verify we get valid results
+	if len(episodes) == 0 {
+		t.Error("Expected at least one episode")
+	}
+}
+
+func TestExtractRepoName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "/path/to/myrepo",
+			expected: "myrepo",
+		},
+		{
+			input:    "https://github.com/user/myrepo",
+			expected: "myrepo",
+		},
+		{
+			input:    "https://github.com/user/myrepo.git",
+			expected: "myrepo",
+		},
+		{
+			input:    "myrepo",
+			expected: "myrepo",
+		},
+		{
+			input:    "/path/to/myrepo/",
+			expected: "myrepo",
+		},
+		{
+			input:    "https://github.com/user/myrepo/",
+			expected: "myrepo",
+		},
+		{
+			input:    "https://github.com/Yates-Labs/thunk",
+			expected: "thunk",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := extractRepoName(tt.input)
+			if result != tt.expected {
+				t.Errorf("extractRepoName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAnalyzeRepository_EndToEnd(t *testing.T) {
+	ctx := context.Background()
+
+	// Full end-to-end test
+	episodes, err := AnalyzeRepository(ctx, "https://github.com/Yates-Labs/thunk")
+	if err != nil {
+		t.Fatalf("End-to-end analysis failed: %v", err)
+	}
+
+	if len(episodes) == 0 {
+		t.Fatal("Expected at least one episode")
+	}
+
+	t.Logf("Generated %d episodes", len(episodes))
+
+	// Verify data quality
+	totalCommits := 0
+	for i, episode := range episodes {
+		t.Logf("Episode %d (%s): %d commits", i+1, episode.ID, len(episode.Commits))
+		totalCommits += len(episode.Commits)
+
+		// Each episode should have at least one commit
+		if len(episode.Commits) == 0 {
+			t.Errorf("Episode %d is empty", i)
+		}
+
+		// Verify commits are properly ordered (oldest to newest within episode)
+		for j := 1; j < len(episode.Commits); j++ {
+			if episode.Commits[j].CommittedAt.Before(episode.Commits[j-1].CommittedAt) {
+				t.Errorf("Episode %d has commits out of chronological order", i)
+			}
+		}
+	}
+
+	if totalCommits == 0 {
+		t.Error("No commits found across all episodes")
+	}
+
+	t.Logf("Total commits across all episodes: %d", totalCommits)
+}


### PR DESCRIPTION
closes #15 

This PR adds the orchestrator module to coordinate data flow between ingestion and clustering.

The main function is AnalyzeRepository(ctx, repo) which accepts a local path or remote URL, invokes git ingestion to build a RepositoryActivity, passes it to the cluster grouping function, and returns the generated episodes.