### PR TITLE
feat: Added github artifact adapter and integrated with orchestrator.

### DIFF
--- a/internal/adapter/github.go
+++ b/internal/adapter/github.go
@@ -1,0 +1,433 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/Yates-Labs/thunk/internal/cluster"
+	"github.com/Yates-Labs/thunk/internal/ingest/git"
+	githubmodel "github.com/Yates-Labs/thunk/internal/ingest/github"
+)
+
+// Common errors for adapter operations
+var (
+	ErrInvalidIssueType = errors.New("invalid issue type: expected *github.Issue")
+	ErrInvalidPRType    = errors.New("invalid pull request type: expected *github.PullRequest")
+)
+
+// GitHubAdapter implements the Adapter interface for GitHub
+type GitHubAdapter struct{}
+
+// NewGitHubAdapter creates a new GitHub adapter instance
+func NewGitHubAdapter() *GitHubAdapter {
+	return &GitHubAdapter{}
+}
+
+// GetPlatform returns the GitHub platform identifier
+func (a *GitHubAdapter) GetPlatform() cluster.SourcePlatform {
+	return cluster.PlatformGitHub
+}
+
+// ConvertIssue converts a GitHub issue to a cluster.Artifact
+func (a *GitHubAdapter) ConvertIssue(issue interface{}) (*cluster.Artifact, error) {
+	ghIssue, ok := issue.(*githubmodel.Issue)
+	if !ok {
+		return nil, ErrInvalidIssueType
+	}
+	return convertGitHubIssue(ghIssue), nil
+}
+
+// ConvertPullRequest converts a GitHub pull request to a cluster.Artifact
+func (a *GitHubAdapter) ConvertPullRequest(pr interface{}) (*cluster.Artifact, error) {
+	ghPR, ok := pr.(*githubmodel.PullRequest)
+	if !ok {
+		return nil, ErrInvalidPRType
+	}
+	return convertGitHubPullRequest(ghPR), nil
+}
+
+// FetchArtifacts fetches all artifacts (issues and PRs) from GitHub
+func (a *GitHubAdapter) FetchArtifacts(ctx context.Context, token, owner, repo string) ([]cluster.Artifact, error) {
+	// Create GitHub client
+	client := githubmodel.NewClient(token)
+
+	var artifacts []cluster.Artifact
+
+	fmt.Printf("Fetching issues from GitHub...\n")
+
+	// Fetch all issues (this includes both issues and PRs in GitHub's API)
+	ghIssues, err := githubmodel.ListAllIssues(ctx, client, owner, repo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch issues: %w", err)
+	}
+
+	fmt.Printf("Found %d issues/PRs, converting...\n", len(ghIssues))
+
+	// Convert issues directly from the lightweight API objects
+	for _, ghIssue := range ghIssues {
+		if ghIssue.IsPullRequest() {
+			// Skip PRs here - we'll get them from the PR endpoint
+			continue
+		}
+
+		// Convert lightweight issue to our model
+		issue := githubmodel.ParseIssue(ghIssue)
+
+		// Convert to artifact using adapter
+		artifact, err := a.ConvertIssue(issue)
+		if err != nil {
+			fmt.Printf("Warning: failed to convert issue #%d: %v\n", ghIssue.GetNumber(), err)
+			continue
+		}
+
+		artifacts = append(artifacts, *artifact)
+	}
+
+	fmt.Printf("Fetching pull requests from GitHub...\n")
+
+	// Fetch all pull requests with lightweight details
+	ghPRs, err := githubmodel.ListAllPullRequests(ctx, client, owner, repo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch pull requests: %w", err)
+	}
+
+	fmt.Printf("Found %d PRs, converting...\n", len(ghPRs))
+
+	for _, ghPR := range ghPRs {
+		// Convert lightweight PR to our model
+		pr := githubmodel.ParsePullRequest(ghPR)
+
+		// Convert to artifact using adapter
+		artifact, err := a.ConvertPullRequest(pr)
+		if err != nil {
+			fmt.Printf("Warning: failed to convert PR #%d: %v\n", ghPR.GetNumber(), err)
+			continue
+		}
+
+		artifacts = append(artifacts, *artifact)
+	}
+
+	fmt.Printf("Successfully converted %d artifacts\n", len(artifacts))
+
+	return artifacts, nil
+}
+
+// convertGitHubIssue converts a GitHub issue to a standardized cluster.Artifact
+// convertGitHubIssue converts a GitHub issue to a standardized cluster.Artifact
+func convertGitHubIssue(issue *githubmodel.Issue) *cluster.Artifact {
+	artifact := &cluster.Artifact{
+		ID:          fmt.Sprintf("issue-%d", issue.ID),
+		Number:      issue.Number,
+		Type:        cluster.ArtifactIssue,
+		Title:       issue.Title,
+		Description: issue.Body,
+		State:       issue.State,
+		Author: git.Author{
+			Name:  issue.Author,
+			Email: "", // GitHub API doesn't provide email in issue context
+		},
+		Assignees: issue.Assignees,
+		Labels:    issue.Labels,
+		CreatedAt: issue.CreatedAt,
+		UpdatedAt: issue.UpdatedAt,
+		ClosedAt:  issue.ClosedAt,
+		URL:       issue.HTMLURL,
+	}
+
+	// Convert discussions (comments)
+	artifact.Discussions = make([]cluster.Discussion, 0, len(issue.Comments))
+	for _, comment := range issue.Comments {
+		artifact.Discussions = append(artifact.Discussions, convertGitHubComment(comment))
+	}
+
+	// Set metadata
+	artifact.Metadata = cluster.ArtifactMetadata{
+		RelatedArtifacts: extractRelatedArtifacts(issue.CrossReferences),
+	}
+
+	if issue.Milestone != nil {
+		artifact.Metadata.Milestone = issue.Milestone.Title
+		artifact.Metadata.DueDate = issue.Milestone.DueOn
+	}
+
+	return artifact
+}
+
+// convertGitHubPullRequest converts a GitHub pull request to a standardized cluster.Artifact
+func convertGitHubPullRequest(pr *githubmodel.PullRequest) *cluster.Artifact {
+	artifact := &cluster.Artifact{
+		ID:          fmt.Sprintf("pr-%d", pr.ID),
+		Number:      pr.Number,
+		Type:        cluster.ArtifactPullRequest,
+		Title:       pr.Title,
+		Description: pr.Description,
+		State:       normalizeState(pr.State, pr.Merged),
+		Author: git.Author{
+			Name:  pr.Author,
+			Email: "", // GitHub API doesn't provide email in PR context
+		},
+		Assignees: pr.Assignees,
+		Labels:    pr.Labels,
+		CreatedAt: pr.CreatedAt,
+		UpdatedAt: pr.UpdatedAt,
+		ClosedAt:  pr.ClosedAt,
+		MergedAt:  pr.MergedAt,
+		URL:       pr.HTMLURL,
+	}
+
+	// Convert all discussions (comments, review comments, and reviews)
+	artifact.Discussions = make([]cluster.Discussion, 0,
+		len(pr.Comments)+len(pr.ReviewComments)+len(pr.Reviews))
+
+	// Add issue comments
+	for _, comment := range pr.Comments {
+		artifact.Discussions = append(artifact.Discussions, convertGitHubComment(comment))
+	}
+
+	// Add review comments
+	for _, reviewComment := range pr.ReviewComments {
+		artifact.Discussions = append(artifact.Discussions, convertGitHubReviewComment(reviewComment))
+	}
+
+	// Add reviews
+	for _, review := range pr.Reviews {
+		artifact.Discussions = append(artifact.Discussions, convertGitHubReview(review))
+	}
+
+	// Sort discussions by creation time
+	sortDiscussions(artifact.Discussions)
+
+	// Set PR-specific metadata
+	artifact.Metadata = cluster.ArtifactMetadata{
+		BaseBranch:       pr.BaseBranch,
+		HeadBranch:       pr.HeadBranch,
+		Additions:        pr.Additions,
+		Deletions:        pr.Deletions,
+		ChangedFiles:     pr.ChangedFiles,
+		ReviewState:      determineReviewState(pr.Reviews),
+		IsDraft:          pr.Draft,
+		RelatedArtifacts: extractRelatedArtifacts(pr.CrossReferences),
+	}
+
+	if pr.Milestone != nil {
+		artifact.Metadata.Milestone = pr.Milestone.Title
+		artifact.Metadata.DueDate = pr.Milestone.DueOn
+	}
+
+	return artifact
+}
+
+// convertGitHubComment converts a GitHub issue comment to a cluster.Discussion
+func convertGitHubComment(comment githubmodel.Comment) cluster.Discussion {
+	return cluster.Discussion{
+		ID:   fmt.Sprintf("comment-%d", comment.ID),
+		Type: cluster.DiscussionComment,
+		Author: git.Author{
+			Name:  comment.Author,
+			Email: "",
+		},
+		Body:      comment.Body,
+		CreatedAt: comment.CreatedAt,
+		UpdatedAt: comment.UpdatedAt,
+		Reactions: convertGitHubReactions(comment.Reactions),
+	}
+}
+
+// convertGitHubReviewComment converts a GitHub review comment to a cluster.Discussion
+func convertGitHubReviewComment(comment githubmodel.ReviewComment) cluster.Discussion {
+	discussion := cluster.Discussion{
+		ID:   fmt.Sprintf("review-comment-%d", comment.ID),
+		Type: cluster.DiscussionReviewThread,
+		Author: git.Author{
+			Name:  comment.Author,
+			Email: "",
+		},
+		Body:       comment.Body,
+		CreatedAt:  comment.CreatedAt,
+		UpdatedAt:  comment.UpdatedAt,
+		FilePath:   comment.Path,
+		LineNumber: comment.Line,
+		CommitHash: comment.CommitID,
+		Reactions:  convertGitHubReactions(comment.Reactions),
+	}
+
+	// Set thread context if this is a reply
+	if comment.InReplyToID != 0 {
+		discussion.ParentID = fmt.Sprintf("review-comment-%d", comment.InReplyToID)
+		discussion.ThreadID = discussion.ParentID // Use parent as thread ID
+	} else {
+		discussion.ThreadID = discussion.ID // This starts a new thread
+	}
+
+	return discussion
+}
+
+// convertGitHubReview converts a GitHub review to a cluster.Discussion
+func convertGitHubReview(review githubmodel.Review) cluster.Discussion {
+	return cluster.Discussion{
+		ID:   fmt.Sprintf("review-%d", review.ID),
+		Type: cluster.DiscussionReview,
+		Author: git.Author{
+			Name:  review.Author,
+			Email: "",
+		},
+		Body:        review.Body,
+		CreatedAt:   review.SubmittedAt,
+		UpdatedAt:   review.SubmittedAt,
+		ReviewState: normalizeReviewState(review.State),
+	}
+}
+
+// convertGitHubReactions converts GitHub reactions to cluster.Reactions
+func convertGitHubReactions(reactions *githubmodel.Reactions) cluster.Reactions {
+	if reactions == nil {
+		return cluster.Reactions{}
+	}
+
+	return cluster.Reactions{
+		ThumbsUp:   reactions.PlusOne,
+		ThumbsDown: reactions.MinusOne,
+		Laugh:      reactions.Laugh,
+		Hooray:     reactions.Hooray,
+		Confused:   reactions.Confused,
+		Heart:      reactions.Heart,
+		Rocket:     reactions.Rocket,
+		Eyes:       reactions.Eyes,
+		TotalCount: reactions.TotalCount,
+	}
+}
+
+// extractRelatedArtifacts extracts related artifact IDs from cross-references
+func extractRelatedArtifacts(crossRefs []githubmodel.CrossRef) []string {
+	if len(crossRefs) == 0 {
+		return nil
+	}
+
+	related := make([]string, 0, len(crossRefs))
+	for _, ref := range crossRefs {
+		var prefix string
+		if ref.Type == "pull_request" {
+			prefix = "pr"
+		} else {
+			prefix = "issue"
+		}
+		related = append(related, fmt.Sprintf("%s-%d", prefix, ref.Number))
+	}
+	return related
+}
+
+// normalizeState converts GitHub state to a normalized state
+// For PRs, also considers merged status
+func normalizeState(state string, merged bool) string {
+	if merged {
+		return "merged"
+	}
+	return state
+}
+
+// normalizeReviewState converts GitHub review states to normalized states
+func normalizeReviewState(state string) string {
+	switch state {
+	case "APPROVED":
+		return "approved"
+	case "CHANGES_REQUESTED":
+		return "changes_requested"
+	case "COMMENTED":
+		return "commented"
+	case "DISMISSED":
+		return "dismissed"
+	default:
+		return state
+	}
+}
+
+// determineReviewState determines the overall review state from all reviews
+// Priority: changes_requested > approved > commented
+func determineReviewState(reviews []githubmodel.Review) string {
+	if len(reviews) == 0 {
+		return ""
+	}
+
+	hasApproval := false
+	hasChangesRequested := false
+
+	// Use the most recent review from each unique reviewer
+	reviewerStates := make(map[string]string)
+	for _, review := range reviews {
+		// Later reviews override earlier ones
+		reviewerStates[review.Author] = normalizeReviewState(review.State)
+	}
+
+	// Check the final states
+	for _, state := range reviewerStates {
+		switch state {
+		case "changes_requested":
+			hasChangesRequested = true
+		case "approved":
+			hasApproval = true
+		}
+	}
+
+	if hasChangesRequested {
+		return "changes_requested"
+	}
+	if hasApproval {
+		return "approved"
+	}
+	return "commented"
+}
+
+// sortDiscussions sorts discussions by creation time
+func sortDiscussions(discussions []cluster.Discussion) {
+	// Simple bubble sort - small arrays so performance is fine
+	n := len(discussions)
+	for i := 0; i < n-1; i++ {
+		for j := 0; j < n-i-1; j++ {
+			if discussions[j].CreatedAt.After(discussions[j+1].CreatedAt) {
+				discussions[j], discussions[j+1] = discussions[j+1], discussions[j]
+			}
+		}
+	}
+}
+
+// ConvertIssues is a convenience function to convert multiple issues
+func ConvertIssues(issues []*githubmodel.Issue) []*cluster.Artifact {
+	artifacts := make([]*cluster.Artifact, 0, len(issues))
+	for _, issue := range issues {
+		artifacts = append(artifacts, convertGitHubIssue(issue))
+	}
+	return artifacts
+}
+
+// ConvertPullRequests is a convenience function to convert multiple PRs
+func ConvertPullRequests(prs []*githubmodel.PullRequest) []*cluster.Artifact {
+	artifacts := make([]*cluster.Artifact, 0, len(prs))
+	for _, pr := range prs {
+		artifacts = append(artifacts, convertGitHubPullRequest(pr))
+	}
+	return artifacts
+}
+
+// ParseArtifactID parses an artifact ID and returns the type and number
+// Format: "issue-123" or "pr-456"
+func ParseArtifactID(id string) (artifactType string, number int, err error) {
+	var numStr string
+	if len(id) > 6 && id[:6] == "issue-" {
+		artifactType = "issue"
+		numStr = id[6:]
+	} else if len(id) > 3 && id[:3] == "pr-" {
+		artifactType = "pr"
+		numStr = id[3:]
+	} else {
+		return "", 0, fmt.Errorf("invalid artifact ID format: %s", id)
+	}
+
+	number, err = strconv.Atoi(numStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid artifact number in ID %s: %w", id, err)
+	}
+
+	return artifactType, number, nil
+}

--- a/internal/adapter/github_test.go
+++ b/internal/adapter/github_test.go
@@ -1,0 +1,623 @@
+package adapter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Yates-Labs/thunk/internal/cluster"
+	githubmodel "github.com/Yates-Labs/thunk/internal/ingest/github"
+)
+
+// Sample GitHub API responses for testing
+
+func createSampleIssue() *githubmodel.Issue {
+	createdAt := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2024, 1, 16, 12, 0, 0, 0, time.UTC)
+	closedAt := time.Date(2024, 1, 17, 14, 0, 0, 0, time.UTC)
+
+	return &githubmodel.Issue{
+		ID:        12345,
+		Number:    42,
+		Title:     "Fix authentication bug",
+		Body:      "Users are unable to log in with OAuth",
+		State:     "closed",
+		Author:    "alice",
+		Labels:    []string{"bug", "security"},
+		Assignees: []string{"bob", "charlie"},
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+		ClosedAt:  &closedAt,
+		HTMLURL:   "https://github.com/owner/repo/issues/42",
+		Comments: []githubmodel.Comment{
+			{
+				ID:        1001,
+				Author:    "bob",
+				Body:      "I'll investigate this",
+				CreatedAt: time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC),
+				Reactions: &githubmodel.Reactions{
+					TotalCount: 2,
+					PlusOne:    2,
+				},
+			},
+			{
+				ID:        1002,
+				Author:    "charlie",
+				Body:      "Fixed in PR #43",
+				CreatedAt: time.Date(2024, 1, 16, 10, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2024, 1, 16, 10, 0, 0, 0, time.UTC),
+			},
+		},
+		Milestone: &githubmodel.Milestone{
+			ID:     500,
+			Number: 5,
+			Title:  "v1.2.0",
+			DueOn:  &closedAt,
+		},
+		CrossReferences: []githubmodel.CrossRef{
+			{
+				Type:   "pull_request",
+				Number: 43,
+				Title:  "Fix OAuth authentication",
+				State:  "merged",
+				URL:    "https://github.com/owner/repo/pull/43",
+			},
+		},
+	}
+}
+
+func createSamplePullRequest() *githubmodel.PullRequest {
+	createdAt := time.Date(2024, 2, 1, 9, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2024, 2, 3, 15, 0, 0, 0, time.UTC)
+	mergedAt := time.Date(2024, 2, 3, 15, 0, 0, 0, time.UTC)
+
+	return &githubmodel.PullRequest{
+		ID:                 67890,
+		Number:             43,
+		Title:              "Fix OAuth authentication",
+		Description:        "This PR fixes the OAuth authentication bug reported in #42",
+		State:              "closed",
+		Author:             "bob",
+		Labels:             []string{"bug", "security"},
+		Assignees:          []string{"bob"},
+		RequestedReviewers: []string{"alice"},
+		BaseBranch:         "main",
+		HeadBranch:         "fix/oauth-auth",
+		Merged:             true,
+		Draft:              false,
+		Additions:          145,
+		Deletions:          32,
+		ChangedFiles:       5,
+		CreatedAt:          createdAt,
+		UpdatedAt:          updatedAt,
+		MergedAt:           &mergedAt,
+		HTMLURL:            "https://github.com/owner/repo/pull/43",
+		Comments: []githubmodel.Comment{
+			{
+				ID:        2001,
+				Author:    "alice",
+				Body:      "Looks good overall, just a few minor comments",
+				CreatedAt: time.Date(2024, 2, 2, 10, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2024, 2, 2, 10, 0, 0, 0, time.UTC),
+			},
+		},
+		ReviewComments: []githubmodel.ReviewComment{
+			{
+				ID:        3001,
+				Author:    "alice",
+				Body:      "Consider adding error handling here",
+				Path:      "src/auth/oauth.go",
+				Line:      42,
+				CommitID:  "abc123",
+				CreatedAt: time.Date(2024, 2, 2, 10, 30, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2024, 2, 2, 10, 30, 0, 0, time.UTC),
+				DiffHunk:  "@@ -40,6 +40,8 @@\n func authenticate() {\n+  // new code\n }",
+			},
+			{
+				ID:          3002,
+				Author:      "bob",
+				Body:        "Good catch, I'll add that",
+				Path:        "src/auth/oauth.go",
+				Line:        42,
+				CommitID:    "abc123",
+				InReplyToID: 3001,
+				CreatedAt:   time.Date(2024, 2, 2, 11, 0, 0, 0, time.UTC),
+				UpdatedAt:   time.Date(2024, 2, 2, 11, 0, 0, 0, time.UTC),
+			},
+		},
+		Reviews: []githubmodel.Review{
+			{
+				ID:          4001,
+				Author:      "alice",
+				Body:        "Approved after updates",
+				State:       "APPROVED",
+				SubmittedAt: time.Date(2024, 2, 3, 14, 0, 0, 0, time.UTC),
+			},
+		},
+		Milestone: &githubmodel.Milestone{
+			ID:     500,
+			Number: 5,
+			Title:  "v1.2.0",
+		},
+		CrossReferences: []githubmodel.CrossRef{
+			{
+				Type:   "issue",
+				Number: 42,
+				Title:  "Fix authentication bug",
+				State:  "closed",
+				URL:    "https://github.com/owner/repo/issues/42",
+			},
+		},
+	}
+}
+
+// Test converting a GitHub issue to a cluster artifact
+func TestConvertGitHubIssue(t *testing.T) {
+	issue := createSampleIssue()
+	artifact := convertGitHubIssue(issue)
+
+	// Verify basic fields
+	if artifact.ID != "issue-12345" {
+		t.Errorf("Expected ID 'issue-12345', got '%s'", artifact.ID)
+	}
+	if artifact.Number != 42 {
+		t.Errorf("Expected Number 42, got %d", artifact.Number)
+	}
+	if artifact.Type != cluster.ArtifactIssue {
+		t.Errorf("Expected Type 'issue', got '%s'", artifact.Type)
+	}
+	if artifact.Title != "Fix authentication bug" {
+		t.Errorf("Expected Title 'Fix authentication bug', got '%s'", artifact.Title)
+	}
+	if artifact.State != "closed" {
+		t.Errorf("Expected State 'closed', got '%s'", artifact.State)
+	}
+	if artifact.Author.Name != "alice" {
+		t.Errorf("Expected Author 'alice', got '%s'", artifact.Author.Name)
+	}
+
+	// Verify labels
+	if len(artifact.Labels) != 2 {
+		t.Errorf("Expected 2 labels, got %d", len(artifact.Labels))
+	}
+
+	// Verify assignees
+	if len(artifact.Assignees) != 2 {
+		t.Errorf("Expected 2 assignees, got %d", len(artifact.Assignees))
+	}
+
+	// Verify discussions (comments)
+	if len(artifact.Discussions) != 2 {
+		t.Errorf("Expected 2 discussions, got %d", len(artifact.Discussions))
+	}
+	if artifact.Discussions[0].Type != cluster.DiscussionComment {
+		t.Errorf("Expected discussion type 'comment', got '%s'", artifact.Discussions[0].Type)
+	}
+	if artifact.Discussions[0].Author.Name != "bob" {
+		t.Errorf("Expected first comment author 'bob', got '%s'", artifact.Discussions[0].Author.Name)
+	}
+	if artifact.Discussions[0].Reactions.TotalCount != 2 {
+		t.Errorf("Expected 2 reactions, got %d", artifact.Discussions[0].Reactions.TotalCount)
+	}
+
+	// Verify metadata
+	if artifact.Metadata.Milestone != "v1.2.0" {
+		t.Errorf("Expected Milestone 'v1.2.0', got '%s'", artifact.Metadata.Milestone)
+	}
+	if len(artifact.Metadata.RelatedArtifacts) != 1 {
+		t.Errorf("Expected 1 related artifact, got %d", len(artifact.Metadata.RelatedArtifacts))
+	}
+	if artifact.Metadata.RelatedArtifacts[0] != "pr-43" {
+		t.Errorf("Expected related artifact 'pr-43', got '%s'", artifact.Metadata.RelatedArtifacts[0])
+	}
+
+	// Verify timestamps
+	if artifact.ClosedAt == nil {
+		t.Error("Expected ClosedAt to be set")
+	}
+}
+
+// Test converting a GitHub pull request to a cluster artifact
+func TestConvertGitHubPullRequest(t *testing.T) {
+	pr := createSamplePullRequest()
+	artifact := convertGitHubPullRequest(pr)
+
+	// Verify basic fields
+	if artifact.ID != "pr-67890" {
+		t.Errorf("Expected ID 'pr-67890', got '%s'", artifact.ID)
+	}
+	if artifact.Number != 43 {
+		t.Errorf("Expected Number 43, got %d", artifact.Number)
+	}
+	if artifact.Type != cluster.ArtifactPullRequest {
+		t.Errorf("Expected Type 'pull_request', got '%s'", artifact.Type)
+	}
+	if artifact.Title != "Fix OAuth authentication" {
+		t.Errorf("Expected Title 'Fix OAuth authentication', got '%s'", artifact.Title)
+	}
+	if artifact.State != "merged" {
+		t.Errorf("Expected State 'merged', got '%s'", artifact.State)
+	}
+	if artifact.Author.Name != "bob" {
+		t.Errorf("Expected Author 'bob', got '%s'", artifact.Author.Name)
+	}
+
+	// Verify PR-specific metadata
+	if artifact.Metadata.BaseBranch != "main" {
+		t.Errorf("Expected BaseBranch 'main', got '%s'", artifact.Metadata.BaseBranch)
+	}
+	if artifact.Metadata.HeadBranch != "fix/oauth-auth" {
+		t.Errorf("Expected HeadBranch 'fix/oauth-auth', got '%s'", artifact.Metadata.HeadBranch)
+	}
+	if artifact.Metadata.Additions != 145 {
+		t.Errorf("Expected Additions 145, got %d", artifact.Metadata.Additions)
+	}
+	if artifact.Metadata.Deletions != 32 {
+		t.Errorf("Expected Deletions 32, got %d", artifact.Metadata.Deletions)
+	}
+	if artifact.Metadata.ChangedFiles != 5 {
+		t.Errorf("Expected ChangedFiles 5, got %d", artifact.Metadata.ChangedFiles)
+	}
+	if artifact.Metadata.IsDraft {
+		t.Error("Expected IsDraft to be false")
+	}
+
+	// Verify discussions include all types (comments, review comments, reviews)
+	expectedDiscussions := 4 // 1 comment + 2 review comments + 1 review
+	if len(artifact.Discussions) != expectedDiscussions {
+		t.Errorf("Expected %d discussions, got %d", expectedDiscussions, len(artifact.Discussions))
+	}
+
+	// Find and verify the review comment thread
+	var foundReviewComment bool
+	var foundReviewReply bool
+	for _, d := range artifact.Discussions {
+		if d.Type == cluster.DiscussionReviewThread {
+			if d.FilePath == "src/auth/oauth.go" && d.LineNumber == 42 {
+				foundReviewComment = true
+				if d.ParentID == "" {
+					// This is the parent comment
+					if d.ThreadID != d.ID {
+						t.Errorf("Expected ThreadID to equal ID for parent comment")
+					}
+				} else {
+					// This is a reply
+					foundReviewReply = true
+					if d.ParentID != "review-comment-3001" {
+						t.Errorf("Expected ParentID 'review-comment-3001', got '%s'", d.ParentID)
+					}
+				}
+			}
+		}
+	}
+	if !foundReviewComment {
+		t.Error("Expected to find review comment on src/auth/oauth.go:42")
+	}
+	if !foundReviewReply {
+		t.Error("Expected to find review comment reply")
+	}
+
+	// Verify review state
+	if artifact.Metadata.ReviewState != "approved" {
+		t.Errorf("Expected ReviewState 'approved', got '%s'", artifact.Metadata.ReviewState)
+	}
+
+	// Verify related artifacts
+	if len(artifact.Metadata.RelatedArtifacts) != 1 {
+		t.Errorf("Expected 1 related artifact, got %d", len(artifact.Metadata.RelatedArtifacts))
+	}
+	if artifact.Metadata.RelatedArtifacts[0] != "issue-42" {
+		t.Errorf("Expected related artifact 'issue-42', got '%s'", artifact.Metadata.RelatedArtifacts[0])
+	}
+
+	// Verify merged timestamp
+	if artifact.MergedAt == nil {
+		t.Error("Expected MergedAt to be set")
+	}
+}
+
+// Test the adapter interface implementation
+func TestGitHubAdapter_ConvertIssue(t *testing.T) {
+	adapter := NewGitHubAdapter()
+	issue := createSampleIssue()
+
+	artifact, err := adapter.ConvertIssue(issue)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if artifact.Number != 42 {
+		t.Errorf("Expected Number 42, got %d", artifact.Number)
+	}
+}
+
+func TestGitHubAdapter_ConvertPullRequest(t *testing.T) {
+	adapter := NewGitHubAdapter()
+	pr := createSamplePullRequest()
+
+	artifact, err := adapter.ConvertPullRequest(pr)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if artifact.Number != 43 {
+		t.Errorf("Expected Number 43, got %d", artifact.Number)
+	}
+}
+
+func TestGitHubAdapter_GetPlatform(t *testing.T) {
+	adapter := NewGitHubAdapter()
+	if adapter.GetPlatform() != cluster.PlatformGitHub {
+		t.Errorf("Expected platform 'github', got '%s'", adapter.GetPlatform())
+	}
+}
+
+func TestGitHubAdapter_InvalidIssueType(t *testing.T) {
+	adapter := NewGitHubAdapter()
+	_, err := adapter.ConvertIssue("invalid")
+	if err != ErrInvalidIssueType {
+		t.Errorf("Expected ErrInvalidIssueType, got %v", err)
+	}
+}
+
+func TestGitHubAdapter_InvalidPRType(t *testing.T) {
+	adapter := NewGitHubAdapter()
+	_, err := adapter.ConvertPullRequest("invalid")
+	if err != ErrInvalidPRType {
+		t.Errorf("Expected ErrInvalidPRType, got %v", err)
+	}
+}
+
+// Test review state determination
+func TestDetermineReviewState(t *testing.T) {
+	tests := []struct {
+		name     string
+		reviews  []githubmodel.Review
+		expected string
+	}{
+		{
+			name:     "No reviews",
+			reviews:  []githubmodel.Review{},
+			expected: "",
+		},
+		{
+			name: "Single approval",
+			reviews: []githubmodel.Review{
+				{ID: 1, Author: "alice", State: "APPROVED", SubmittedAt: time.Now()},
+			},
+			expected: "approved",
+		},
+		{
+			name: "Single changes requested",
+			reviews: []githubmodel.Review{
+				{ID: 1, Author: "alice", State: "CHANGES_REQUESTED", SubmittedAt: time.Now()},
+			},
+			expected: "changes_requested",
+		},
+		{
+			name: "Changes requested overrides approval",
+			reviews: []githubmodel.Review{
+				{ID: 1, Author: "alice", State: "APPROVED", SubmittedAt: time.Now()},
+				{ID: 2, Author: "bob", State: "CHANGES_REQUESTED", SubmittedAt: time.Now()},
+			},
+			expected: "changes_requested",
+		},
+		{
+			name: "Latest review from same reviewer wins",
+			reviews: []githubmodel.Review{
+				{ID: 1, Author: "alice", State: "CHANGES_REQUESTED", SubmittedAt: time.Now()},
+				{ID: 2, Author: "alice", State: "APPROVED", SubmittedAt: time.Now().Add(time.Hour)},
+			},
+			expected: "approved",
+		},
+		{
+			name: "Only comments",
+			reviews: []githubmodel.Review{
+				{ID: 1, Author: "alice", State: "COMMENTED", SubmittedAt: time.Now()},
+			},
+			expected: "commented",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := determineReviewState(tt.reviews)
+			if result != tt.expected {
+				t.Errorf("Expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
+}
+
+// Test state normalization
+func TestNormalizeState(t *testing.T) {
+	tests := []struct {
+		state    string
+		merged   bool
+		expected string
+	}{
+		{"open", false, "open"},
+		{"closed", false, "closed"},
+		{"closed", true, "merged"},
+		{"open", true, "merged"}, // Shouldn't happen but merged takes precedence
+	}
+
+	for _, tt := range tests {
+		result := normalizeState(tt.state, tt.merged)
+		if result != tt.expected {
+			t.Errorf("normalizeState(%s, %v) = %s, expected %s",
+				tt.state, tt.merged, result, tt.expected)
+		}
+	}
+}
+
+// Test review state normalization
+func TestNormalizeReviewState(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"APPROVED", "approved"},
+		{"CHANGES_REQUESTED", "changes_requested"},
+		{"COMMENTED", "commented"},
+		{"DISMISSED", "dismissed"},
+		{"UNKNOWN", "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		result := normalizeReviewState(tt.input)
+		if result != tt.expected {
+			t.Errorf("normalizeReviewState(%s) = %s, expected %s",
+				tt.input, result, tt.expected)
+		}
+	}
+}
+
+// Test artifact ID parsing
+func TestParseArtifactID(t *testing.T) {
+	tests := []struct {
+		id          string
+		expectType  string
+		expectNum   int
+		expectError bool
+	}{
+		{"issue-42", "issue", 42, false},
+		{"pr-123", "pr", 123, false},
+		{"issue-1", "issue", 1, false},
+		{"invalid", "", 0, true},
+		{"issue-abc", "", 0, true},
+		{"pr-", "", 0, true},
+	}
+
+	for _, tt := range tests {
+		artType, num, err := ParseArtifactID(tt.id)
+		if tt.expectError {
+			if err == nil {
+				t.Errorf("Expected error for ID '%s', got nil", tt.id)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Unexpected error for ID '%s': %v", tt.id, err)
+			}
+			if artType != tt.expectType {
+				t.Errorf("Expected type '%s', got '%s'", tt.expectType, artType)
+			}
+			if num != tt.expectNum {
+				t.Errorf("Expected number %d, got %d", tt.expectNum, num)
+			}
+		}
+	}
+}
+
+// Test batch conversion functions
+func TestConvertIssues(t *testing.T) {
+	issues := []*githubmodel.Issue{
+		createSampleIssue(),
+		{
+			ID:        99999,
+			Number:    100,
+			Title:     "Another issue",
+			State:     "open",
+			Author:    "dave",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	}
+
+	artifacts := ConvertIssues(issues)
+	if len(artifacts) != 2 {
+		t.Errorf("Expected 2 artifacts, got %d", len(artifacts))
+	}
+	if artifacts[0].Number != 42 {
+		t.Errorf("Expected first artifact number 42, got %d", artifacts[0].Number)
+	}
+	if artifacts[1].Number != 100 {
+		t.Errorf("Expected second artifact number 100, got %d", artifacts[1].Number)
+	}
+}
+
+func TestConvertPullRequests(t *testing.T) {
+	prs := []*githubmodel.PullRequest{
+		createSamplePullRequest(),
+		{
+			ID:         11111,
+			Number:     200,
+			Title:      "Another PR",
+			State:      "open",
+			Author:     "eve",
+			BaseBranch: "main",
+			HeadBranch: "feature/new",
+			Merged:     false,
+			Draft:      true,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+	}
+
+	artifacts := ConvertPullRequests(prs)
+	if len(artifacts) != 2 {
+		t.Errorf("Expected 2 artifacts, got %d", len(artifacts))
+	}
+	if artifacts[0].Number != 43 {
+		t.Errorf("Expected first artifact number 43, got %d", artifacts[0].Number)
+	}
+	if artifacts[1].Number != 200 {
+		t.Errorf("Expected second artifact number 200, got %d", artifacts[1].Number)
+	}
+	if !artifacts[1].Metadata.IsDraft {
+		t.Error("Expected second artifact to be draft")
+	}
+}
+
+// Test discussion sorting
+func TestSortDiscussions(t *testing.T) {
+	now := time.Now()
+	discussions := []cluster.Discussion{
+		{ID: "3", CreatedAt: now.Add(2 * time.Hour)},
+		{ID: "1", CreatedAt: now},
+		{ID: "2", CreatedAt: now.Add(1 * time.Hour)},
+	}
+
+	sortDiscussions(discussions)
+
+	if discussions[0].ID != "1" {
+		t.Errorf("Expected first discussion ID '1', got '%s'", discussions[0].ID)
+	}
+	if discussions[1].ID != "2" {
+		t.Errorf("Expected second discussion ID '2', got '%s'", discussions[1].ID)
+	}
+	if discussions[2].ID != "3" {
+		t.Errorf("Expected third discussion ID '3', got '%s'", discussions[2].ID)
+	}
+}
+
+// Test extracting related artifacts
+func TestExtractRelatedArtifacts(t *testing.T) {
+	crossRefs := []githubmodel.CrossRef{
+		{Type: "issue", Number: 10, Title: "Issue 10"},
+		{Type: "pull_request", Number: 20, Title: "PR 20"},
+		{Type: "issue", Number: 30, Title: "Issue 30"},
+	}
+
+	related := extractRelatedArtifacts(crossRefs)
+	if len(related) != 3 {
+		t.Errorf("Expected 3 related artifacts, got %d", len(related))
+	}
+	if related[0] != "issue-10" {
+		t.Errorf("Expected 'issue-10', got '%s'", related[0])
+	}
+	if related[1] != "pr-20" {
+		t.Errorf("Expected 'pr-20', got '%s'", related[1])
+	}
+	if related[2] != "issue-30" {
+		t.Errorf("Expected 'issue-30', got '%s'", related[2])
+	}
+}
+
+// Test empty cross-references
+func TestExtractRelatedArtifacts_Empty(t *testing.T) {
+	related := extractRelatedArtifacts([]githubmodel.CrossRef{})
+	if related != nil {
+		t.Errorf("Expected nil for empty cross-references, got %v", related)
+	}
+}

--- a/internal/adapter/model.go
+++ b/internal/adapter/model.go
@@ -1,0 +1,23 @@
+package adapter
+
+import (
+	"context"
+
+	"github.com/Yates-Labs/thunk/internal/cluster"
+)
+
+// Adapter defines the interface for converting platform-specific artifacts
+// into the standardized cluster.Artifact model
+type Adapter interface {
+	// ConvertIssue converts a platform-specific issue to a cluster.Artifact
+	ConvertIssue(issue interface{}) (*cluster.Artifact, error)
+
+	// ConvertPullRequest converts a platform-specific pull request to a cluster.Artifact
+	ConvertPullRequest(pr interface{}) (*cluster.Artifact, error)
+
+	// GetPlatform returns the source platform identifier
+	GetPlatform() cluster.SourcePlatform
+
+	// FetchArtifacts fetches all artifacts (issues, PRs, etc.) as a standardized type from the platform
+	FetchArtifacts(ctx context.Context, token, owner, repo string) ([]cluster.Artifact, error)
+}

--- a/internal/orchestrator/utils.go
+++ b/internal/orchestrator/utils.go
@@ -1,0 +1,80 @@
+package orchestrator
+
+import (
+	"strings"
+
+	"github.com/Yates-Labs/thunk/internal/cluster"
+)
+
+// extractRepoName extracts the repository name from a path or URL
+func extractRepoName(repo string) string {
+	// Remove trailing slash if present
+	if len(repo) > 0 && repo[len(repo)-1] == '/' {
+		repo = repo[:len(repo)-1]
+	}
+
+	// Find the last slash
+	lastSlash := -1
+	for i := len(repo) - 1; i >= 0; i-- {
+		if repo[i] == '/' {
+			lastSlash = i
+			break
+		}
+	}
+
+	// Extract name after last slash
+	name := repo
+	if lastSlash >= 0 && lastSlash < len(repo)-1 {
+		name = repo[lastSlash+1:]
+	}
+
+	// Remove .git suffix if present
+	if len(name) > 4 && name[len(name)-4:] == ".git" {
+		name = name[:len(name)-4]
+	}
+
+	return name
+}
+
+// detectPlatform detects the source platform from a repository URL
+// Returns platform, owner, and repo name
+func detectPlatform(repoURL string) (cluster.SourcePlatform, string, string) {
+	// Check for GitHub
+	if strings.Contains(repoURL, "github.com") {
+		owner, repo := parseHostedGitURL(repoURL, "github.com")
+		return cluster.PlatformGitHub, owner, repo
+	}
+
+	// ? We would add support for other platforms here.
+
+	// Default to Git for local paths or unknown URLs
+	return cluster.PlatformGit, "", extractRepoName(repoURL)
+}
+
+// parseHostedGitURL is a generic parser for hosted git services
+func parseHostedGitURL(url, host string) (owner, repo string) {
+	// Remove protocol if present
+	url = strings.TrimPrefix(url, "https://")
+	url = strings.TrimPrefix(url, "http://")
+	url = strings.TrimPrefix(url, "git@")
+
+	// Replace colon with slash for SSH URLs
+	url = strings.Replace(url, ":", "/", 1)
+
+	// Remove host prefix
+	url = strings.TrimPrefix(url, host+"/")
+
+	// Remove trailing .git
+	url = strings.TrimSuffix(url, ".git")
+
+	// Remove trailing slash
+	url = strings.TrimSuffix(url, "/")
+
+	// Split into parts
+	parts := strings.Split(url, "/")
+	if len(parts) >= 2 {
+		return parts[0], parts[1]
+	}
+
+	return "", url
+}


### PR DESCRIPTION
closes #24 

Created the `internal/adapter` module with an `Adapter` interface that will allow us to abstract our platform(GitHub, AzDo, GitLab, etc.) specific enrichments from the orchestrator. Added the `GitHubAdapter` struct which implements `Adapter` and supports fetching github-specific artifact information from the `internal/ingest/github` module. 

Added two new functions to `internal/ingest/github/github.go` to support the `GitHubAdapter`:
1. `ListAllIssues()`
2. `ListAllPullRequests()`


All new functionality has been unit tested.